### PR TITLE
Generate parsable string from PackageGenerationParameters

### DIFF
--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -738,7 +738,9 @@ public class BagItPackageAssembler implements PackageAssembler {
             try {
                 CompressorOutputStream compressedStream = new CompressorStreamFactory()
                         .createCompressorOutputStream(compressionFormat, new FileOutputStream(compressedFile));
-                IOUtils.copy(new FileInputStream(file), compressedStream);
+                FileInputStream uncompressedStream = new FileInputStream(file);
+                IOUtils.copy(uncompressedStream, compressedStream);
+                uncompressedStream.close();
                 compressedStream.close();
             } catch (FileNotFoundException e) {
                 throw new PackageToolException(PackagingToolReturnInfo.PKG_FILE_NOT_FOUND_EXCEPTION, e,

--- a/dcs-packaging-tool-model/src/main/java/org/dataconservancy/packaging/tool/model/PackageGenerationParameters.java
+++ b/dcs-packaging-tool-model/src/main/java/org/dataconservancy/packaging/tool/model/PackageGenerationParameters.java
@@ -190,4 +190,39 @@ public class PackageGenerationParameters {
                 "params=" + params +
                 '}';
     }
+
+    /**
+     * Creates a string representation of the package generation parameters.
+     * The string can be parsed by PropertiesConfigurationParametersBuilder.buildParameters(),
+     * which allows it to be passed as a stream by applications to the packaging classes.
+     * @return String representation of the current parameter set.
+     */
+    public String toParametersString() {
+        StringBuilder builder = new StringBuilder();
+        // Add each parameter
+        for (String key : getKeys()) {
+            List<String> vals = getParam(key);
+            if (vals != null && !vals.isEmpty()) {
+                if (vals.size() == 1) {
+                    // Add a parameter with a single value
+                    String addition = key + "=" + vals.get(0) + "\n";
+                    builder.append(addition);
+                } else {
+                    // Add a parameter with multiple values
+                    boolean multiple = false;
+                    String addition = key + "=";
+                    builder.append(addition);
+                    for (String val : vals) {
+                        if (multiple) {
+                            builder.append(",");
+                        }
+                        builder.append(val);
+                        multiple = true;
+                    }
+                    builder.append("\n");
+                }
+            }
+        }
+        return builder.toString();
+    }
 }


### PR DESCRIPTION
A new method is added to PackageGenerationParameters to produce a string
representation of the parameters which is parsable by the
PropertiesConfiguration.load() method.  The AutomatedPackageTool needs
to generate a stream from this string and pass it to the packager, which
reads the parameters from the stream.  The existing toString() method
does not produce a parsable string.  Because that method appears to be
used only to print debug output, it could be replaced by the new method,
if desired.