### PR TITLE
Close file when packaging

### DIFF
--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -738,7 +738,9 @@ public class BagItPackageAssembler implements PackageAssembler {
             try {
                 CompressorOutputStream compressedStream = new CompressorStreamFactory()
                         .createCompressorOutputStream(compressionFormat, new FileOutputStream(compressedFile));
-                IOUtils.copy(new FileInputStream(file), compressedStream);
+                FileInputStream uncompressedStream = new FileInputStream(file);
+                IOUtils.copy(uncompressedStream, compressedStream);
+                uncompressedStream.close();
                 compressedStream.close();
             } catch (FileNotFoundException e) {
                 throw new PackageToolException(PackagingToolReturnInfo.PKG_FILE_NOT_FOUND_EXCEPTION, e,


### PR DESCRIPTION
A file cleanup operation was failing in the Automated Package Tool
because a file stream remained open to the uncompressed package file in
the staging area.  This was caused by a stream constructor used as a
parameter to a copy method.  The stream is now constructed before the
copy call and closed explicitly afterward.