### PR TITLE
Fix unit tests on Windows - Addresses issue #24

### DIFF
--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/IPMServiceTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/IPMServiceTest.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -133,7 +134,7 @@ public class IPMServiceTest {
 
         try {
             Files.createSymbolicLink(link, subdir.toPath());
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException | FileSystemException e) {
             /* Nothing we can do if the system doesn't support symlinks */
             return;
         }
@@ -166,7 +167,7 @@ public class IPMServiceTest {
 
         try {
             Files.createSymbolicLink(link, linkedFile.toPath());
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException | FileSystemException e) {
             /* Nothing we can do if the system doesn't support symlinks */
             return;
         }
@@ -203,7 +204,7 @@ public class IPMServiceTest {
 
         try {
             Files.createSymbolicLink(link, linkedDir.toPath());
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException | FileSystemException e) {
             /* Nothing we can do if the system doesn't support symlinks */
             return;
         }

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/FilenameValidatorServiceTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/FilenameValidatorServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -51,7 +52,7 @@ public class FilenameValidatorServiceTest {
 
         try {
             Files.createSymbolicLink(link, tempDir.toPath());
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException | FileSystemException e) {
             /* Nothing we can do if the system doesn't support symlinks */
             return;
         }


### PR DESCRIPTION
Several tests throw exceptions when creating symbolic links, and the
catch statement only worked on Linux.  Additionally catching the
FileSystemException allows the tests to pass on Windows.