### PR TITLE
Fix issue #23 - Unit tests fail on Windows because of different EOLs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Make sure line endings are correct for SER files so tests run on Windows
+*.ser text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ release.properties
 *.releaseBackup
 *.bak
 bin/
-.gitattributes
 .gitignore


### PR DESCRIPTION
Several SER files were having their EOLs modified when downloaded from
Git on Windows, causing some unit tests to fail due to string
comparisons.  Git attributes are now set to prevent the change, and the
.gitattributes files is no longer ignored.  Tested locally by editing
the SER files to repair EOLs.