### PR TITLE
Automatically remediate package resource paths

### DIFF
--- a/dcs-packaging-tool-api/src/main/java/org/dataconservancy/packaging/tool/api/generator/PackageResourceType.java
+++ b/dcs-packaging-tool-api/src/main/java/org/dataconservancy/packaging/tool/api/generator/PackageResourceType.java
@@ -16,24 +16,76 @@
 
 package org.dataconservancy.packaging.tool.api.generator;
 
+import java.util.Arrays;
+
 /**
- * Describes the type of resource being included in a package. The intended use of this is to
- * support the assigning of locations withing the package to resources of different types.
+ * Describes the type of resource being included in a package, and their relative location inside the package. The
+ * intended use of this is to support the assigning of locations withing the package to resources of different types.
  */
 public enum PackageResourceType {
-    /** Package data files/content */
-    DATA,
 
-    /** The type for an ORE-ReM file */
-    ORE_REM,
+    /**
+     * Custodial content of the package; domain objects and binary files are both considered to be the custodial
+     * content of the package.
+     */
+    DATA("data"),
 
-    /** Ontologies used in building the package */
-    ONTOLOGY,
+    /**
+     * Domain objects which describe the binary data contained in package.  Considered to be part of the custodial content of the package.
+     */
+    DOMAIN_OBJECT("data/obj"),
 
-    /** Other package-related metadata (e.g.business objects, etc) */
-    METADATA,
+    /**
+     * Binary data contained in the package.  Considered to be part of the custodial content of the package.
+     */
+    BINARY_DATA("data/bin"),
 
-    /** The Package State file */
-    PACKAGE_STATE
+    /**
+     * Metadata describing the custodial content; the {@link #ORE_REM} is considered a form of metadata.
+     */
+    METADATA("META-INF/org.dataconservancy.packaging/PKG-INFO"),
 
+    /**
+     * The ORE-REM describing the graph of objects in the package
+     */
+    ORE_REM("META-INF/org.dataconservancy.packaging/PKG-INFO/ORE-REM"),
+
+    /**
+     * The ontologies used by the domain objects
+     */
+    ONTOLOGY("META-INF/org.dataconservancy.packaging/ONT"),
+
+    /**
+     * The package state, used by the DC Package Tool GUI
+     */
+    PACKAGE_STATE("META-INF/org.dataconservancy.packaging/STATE");
+
+    /**
+     * The relative location of the resource within the package.  Resources of a particular type will placed in the
+     * package underneath this location.
+     */
+    private final String relativePackageLocation;
+
+    private PackageResourceType(String relativePackageLocation) {
+        this.relativePackageLocation = relativePackageLocation;
+    }
+
+    /**
+     * The relative location of the resource within the package.  Resources of a particular type will be placed in the
+     * package somewhere underneath this location.
+     *
+     * @return the relative location of a resource within the package
+     */
+    public String getRelativePackageLocation() {
+        return relativePackageLocation;
+    }
+
+    public static PackageResourceType forRelativePackageLocation(String relativeLocation) {
+        return Arrays.stream(PackageResourceType.values())
+                .findFirst()
+                .filter(candidate -> candidate.getRelativePackageLocation().equals(relativeLocation))
+                .orElseThrow(() ->
+                        new RuntimeException(
+                                "Unable to determine the package resource type for path '" + relativeLocation + "'"));
+    }
 }

--- a/dcs-packaging-tool-gui/src/main/java/org/dataconservancy/packaging/gui/util/PropertyValidationListener.java
+++ b/dcs-packaging-tool-gui/src/main/java/org/dataconservancy/packaging/gui/util/PropertyValidationListener.java
@@ -93,11 +93,6 @@ public class PropertyValidationListener implements ChangeListener<String>, CssCo
                     case URL:
                     case EMAIL:
                     case URI:
-                    case FILE_NAME:
-                        if (validator instanceof C14NValidator) {
-                            String c14nValue = ((C14NValidator) validator).canonicalize(newValue);
-                            textPropertyBox.getPropertyInput().setText(c14nValue);
-                        }
                         textPropertyBox.getChildren().remove(validationLabel);
                         validationImageLabel.setGraphic(successImage);
                         validationImageLabel.setVisible(true);

--- a/dcs-packaging-tool-impl/pom.xml
+++ b/dcs-packaging-tool-impl/pom.xml
@@ -213,7 +213,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -226,6 +226,12 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-all</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
 
@@ -244,6 +250,12 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>compile</scope>
     </dependency>
 
   </dependencies>

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/IPMServiceImpl.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/IPMServiceImpl.java
@@ -18,7 +18,6 @@ package org.dataconservancy.packaging.tool.impl;
  */
 
 
-import org.dataconservancy.dcs.util.FilePathUtil;
 import org.dataconservancy.packaging.tool.api.IPMService;
 import org.dataconservancy.packaging.tool.api.support.NodeComparison;
 import org.dataconservancy.packaging.tool.impl.support.FilenameValidatorService;
@@ -33,7 +32,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,8 +55,6 @@ public class IPMServiceImpl implements IPMService {
         visitedFiles.clear();
         Node root;
         root = createTree(null, path);
-
-        validateFileNames(path);
 
         return root;
     }
@@ -358,8 +354,6 @@ public class IPMServiceImpl implements IPMService {
 
     @Override
     public void remapNode(Node node, Path newPath) throws IOException {
-
-        validateFileNames(newPath);
 
         Path oldPath = null;
         if (node.getFileInfo().getLocation() != null) {

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -283,7 +283,7 @@ public class BagItPackageAssembler implements PackageAssembler {
         }
 
         //Creating payload directory
-        payloadDir = new File(bagBaseDir, "data");
+        payloadDir = new File(bagBaseDir, PackageResourceType.DATA.getRelativePackageLocation());
         //Creating payloadDir
         if (!payloadDir.exists()) {
             log.info("Creating payload dir: " + payloadDir.getPath());
@@ -295,7 +295,7 @@ public class BagItPackageAssembler implements PackageAssembler {
         }
 
         //Creating the package info directory
-        pkgInfoDir = new File(bagBaseDir, "META-INF/org.dataconservancy.packaging/PKG-INFO");
+        pkgInfoDir = new File(bagBaseDir, PackageResourceType.METADATA.getRelativePackageLocation());
         if (!pkgInfoDir.exists()) {
             log.info("Creating package structure dir :" + pkgInfoDir.getPath());
             boolean isDirCreated = pkgInfoDir.mkdirs();
@@ -306,7 +306,7 @@ public class BagItPackageAssembler implements PackageAssembler {
         }
 
         //Creating the ontology directory
-        ontologyDir = new File(bagBaseDir, "META-INF/org.dataconservancy.packaging/ONT");
+        ontologyDir = new File(bagBaseDir, PackageResourceType.ONTOLOGY.getRelativePackageLocation());
         if (!ontologyDir.exists()) {
             log.info("Creating ontology dir :" + ontologyDir.getPath());
             boolean isDirCreated = ontologyDir.mkdirs();
@@ -317,7 +317,7 @@ public class BagItPackageAssembler implements PackageAssembler {
         }
 
         //Creating the ORE-ReM directory
-        remDir = new File(pkgInfoDir, "ORE-REM");
+        remDir = new File(bagBaseDir, PackageResourceType.ORE_REM.getRelativePackageLocation());
         if (!remDir.exists()) {
             log.info("Creating ORE-ReM dir :" + remDir.getPath());
             boolean isDirCreated = remDir.mkdirs();
@@ -328,7 +328,7 @@ public class BagItPackageAssembler implements PackageAssembler {
         }
 
         //Creating the package state directory
-        stateDir = new File(bagBaseDir, "META-INF/org.dataconservancy.packaging/STATE");
+        stateDir = new File(bagBaseDir, PackageResourceType.PACKAGE_STATE.getRelativePackageLocation());
         if (!stateDir.exists()) {
             log.info("Creating Package State dir :" + stateDir.getPath());
             boolean isDirCreated = stateDir.mkdirs();

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -396,7 +396,12 @@ public class BagItPackageAssembler implements PackageAssembler {
                 relativeURI = URI.create(relativeURI.toString() + "/");
             }
 
-            fileURIMap.put(relativeURI, newFile.toURI());
+            URI reserved;
+            if ((reserved = fileURIMap.putIfAbsent(relativeURI, newFile.toURI())) != null) {
+                throw new PackageToolException(PackagingToolReturnInfo.PKG_ASSEMBLER_DUPLICATE_RESOURCE,
+                        String.format("%s has already been reserved as %s", newFile, relativeURI));
+            }
+
 
             if (!isDirectory) {
                 switch(type){

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -354,18 +354,6 @@ public class BagItPackageAssembler implements PackageAssembler {
         try {
             decodedPath = new String(URLCodec.decodeUrl(path.getBytes()));
 
-            log.info("validating path: " + decodedPath);
-
-            if(!isValidPathString(decodedPath)){
-                log.info("Invalid path string:" + decodedPath);
-                try {
-                    FileUtils.cleanDirectory(bagBaseDir);
-                } catch (IOException e) {
-                    log.warn("Exception thrown when cleaning existing directory: " + e.getMessage());
-                }
-                throw new PackageToolException(PackagingToolReturnInfo.PKG_ASSEMBLER_INVALID_FILENAME);
-            }
-
             log.info(("Reserving " + path));
 
             File containingDirectory =  null;
@@ -390,8 +378,9 @@ public class BagItPackageAssembler implements PackageAssembler {
                 log.info("Creating parent folders");
                 boolean isDirCreated = newFile.getParentFile().mkdirs();
                 if (!isDirCreated) {
-                    throw new PackageToolException(PackagingToolReturnInfo.PKG_DIR_CREATION_EXP);
+                    throw new PackageToolException(PackagingToolReturnInfo.PKG_DIR_CREATION_EXP, "  Error creating " + newFile.getParentFile());
                 }
+
                 if (isDirectory && !newFile.mkdir()) {
                     throw new PackageToolException(PackagingToolReturnInfo.PKG_DIR_CREATION_EXP);
                 }
@@ -811,16 +800,26 @@ public class BagItPackageAssembler implements PackageAssembler {
      * @param pathString the string representation of the relative file path
      * @return  whether the file name is valid
      */
-    private boolean isValidPathString(String pathString){
-        for(String component : pathString.split("/")){
-            if(!filenameValidator.isValid(component).getResult()){
-                return false;
+    private ValidatorResult isValidPathString(String pathString) {
+        ValidatorResult result = null;
+
+        if (pathString.getBytes().length > 1024){
+            return new ValidatorResult(false, "Path is longer than 1024 bytes.");
+        }
+
+        for (String component : pathString.split("/")) {
+            if (!(result = filenameValidator.isValid(component)).getResult()) {
+                break;
             }
         }
-        if (pathString.length() > 1024){
-            return false;
+
+        if (result == null) {
+            // Should never happen
+            throw new RuntimeException("Null ValidatorResult received from FilenameValidator for " +
+                    "pathString '" + pathString + "'");
         }
-        return true;
+
+        return result;
     }
 
     private void validateArchivingFormat() {

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/RemediationUtil.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/RemediationUtil.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.generator;
+
+import org.dataconservancy.packaging.tool.api.generator.PackageResourceType;
+import org.dataconservancy.packaging.tool.impl.support.validation.BlacklistedCharacterMatcher;
+import org.dataconservancy.packaging.tool.impl.support.validation.InvalidUtf8CharacterMatcher;
+import org.dataconservancy.packaging.tool.impl.support.validation.SubstitutionRemediation;
+import org.dataconservancy.packaging.tool.impl.support.validation.TruncationRemediation;
+import org.dataconservancy.packaging.tool.model.ipm.Node;
+
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.commons.codec.digest.DigestUtils.shaHex;
+import static org.dataconservancy.packaging.tool.impl.support.validation.TruncationRemediation.Strategy.TRAILING_SUBSTITUTION;
+
+/**
+ * Provides for remediating package resource paths.  The <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">
+ * Data Conservancy BagIt profile §2.2.2.1</a> places significant restrictions on the characters and length of package
+ * resource paths.  Clients may use this class to remediate package resource paths before
+ * {@link org.dataconservancy.packaging.tool.api.generator.PackageAssembler#reserveResource(String, PackageResourceType)
+ * reserving} or {@link org.dataconservancy.packaging.tool.api.generator.PackageAssembler#createResource(String,
+ * PackageResourceType, InputStream) creating} resources.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ * @see <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">Data Conservancy
+ *      BagIt Profile 1.0 §2.2.2.1</a>
+ */
+class RemediationUtil {
+
+    public static final String DOT_DOT = "..";
+    public static final String DOT = ".";
+    /**
+     * Paths that must not be truncated (i.e. they must be preserved in the remediated string).
+     * Note that this List must be sorted with the longest paths at the head of the List.
+     */
+    private static final List<String> RESERVED_PATHS = Arrays.stream(PackageResourceType.values())
+            .map(PackageResourceType::getRelativePackageLocation)
+            .sorted(Comparator.comparingInt(s -> -(s.length())))
+            .collect(Collectors.toList());
+
+    /**
+     * Regular expression that matches file names or path components that are reserved by the Windows/DOS
+     * platform.
+     */
+    private static final String ILLEGAL_DOS_NAMES = "^(CON|PRN|AUX|NUL|COM[0-9]*|LPT[0-9]*)($|\\..*$)";
+
+    /**
+     * Performs remediation by substituting valid characters for invalid characters in path components
+     */
+    private static final SubstitutionRemediation SUBST = new SubstitutionRemediation();
+
+    /**
+     * Performs remediation by shortening path components that violate length limits
+     */
+    private static final TruncationRemediation TRUNC = new TruncationRemediation();
+
+    /**
+     * Remediate the supplied path, correcting any irregularities that would conflict with the BagIt specification or
+     * the identified packaging profile.  If no corrections are needed, the {@code packageResourcePath} will be returned
+     * as-is.
+     *
+     * @param packageResourcePath the full path of a resource in the package, relative to the base directory of the
+     *                            package
+     * @param profileId the profile identifier
+     * @return the remediated path
+     */
+    static String remediatePath(String packageResourcePath, String profileId) {
+        // profileId currently ignored since there's only one profile id supported right now
+
+        StringBuilder toRemediate = new StringBuilder(packageResourcePath);
+        StringBuilder preserved = preservePrefix(toRemediate);
+        int limit = 1024 - preserved.length();
+        String remediatedPath = Arrays.stream(toRemediate.toString().split("/"))
+                .map(StringBuilder::new)
+                .map(pathComponent -> SUBST.remediateMatchingCharacters(pathComponent, 'X', Stream.of(new BlacklistedCharacterMatcher(), new InvalidUtf8CharacterMatcher())))
+                .map(pathComponent -> SUBST.remediateEqualStrings(pathComponent, 'X', DOT_DOT))
+                .map(pathComponent -> SUBST.remediateEqualStrings(pathComponent, 'X', DOT))
+                .map(pathComponent -> SUBST.remediateMatchingStrings(pathComponent, 'X', ILLEGAL_DOS_NAMES))
+                .map(pathComponent -> TRUNC.remediate(pathComponent, 255, TRAILING_SUBSTITUTION))
+                .collect(Collectors.joining("/", "", packageResourcePath.endsWith("/") ? "/" : ""));
+
+        remediatedPath = TRUNC.remediate(new StringBuilder(remediatedPath), limit, TRAILING_SUBSTITUTION);
+
+        return preserved.append(remediatedPath).toString();
+    }
+
+    /**
+     * Searches the supplied {@code packageResourcePath} for reserved path prefixes that should <em>not</em> be subject
+     * to remediation, and removes them from the {@code packageResourcePath}.  The location of {@link PackageResourceType
+     * package resources} are specified by the BagIt specification and the Data Conservancy BagIt profile, and
+     * therefore:
+     * <ol>
+     *     <li>May be assumed to <em>not</em> violate the specification or profile (e.g. paths defined by the
+     *     specification will never have a path component greater than 255 characters, or contain illegal
+     *     characters)</li>
+     *     <li>Must not be subject to remediation (e.g. truncation remediation shall not truncate a portion of the
+     *     reserved path)</li>
+     * </ol>
+     *
+     * @param packageResourcePath the full path of the resource in the package, relative to the base directory of the
+     *                            package
+     * @return the portion of the {@code packageResourcePath} that <em>must</em> be preserved from remediation
+     *         (may be empty)
+     */
+    private static StringBuilder preservePrefix(StringBuilder packageResourcePath) {
+        for (String reserved : RESERVED_PATHS) {
+            final int index = packageResourcePath.indexOf(reserved);
+            if (index < 0) {
+                // nothing to preserve, as the reserved path doesn't exist in the string being remediated
+                continue;
+            }
+
+            // Preserve everything from index 0 in the string being remediated to the ending of the path being preserved
+            // this is a bit greedy, but it does handle the case where the reserved path doesn't start with a /, and
+            // the string being remediated does.
+            StringBuilder preserved = new StringBuilder(packageResourcePath.subSequence(0, index + reserved.length()));
+            packageResourcePath.delete(0, index + reserved.length());
+
+            return preserved;
+        }
+
+        return new StringBuilder();
+    }
+
+    /**
+     * Generate a unique path for {@code node} based on the suggested location.
+     *
+     * @param node the node
+     * @param locationHint the suggested location
+     * @return the unique location based on the node and the hint
+     */
+    static String unique(Node node, String locationHint) throws URISyntaxException {
+        final Path path = Paths.get(locationHint);
+        final StringBuilder remediatedPath = new StringBuilder();
+
+        if (path.isAbsolute()) {
+            remediatedPath.append("/");
+        }
+
+        if (path.getNameCount() > 1) {
+            remediatedPath.append(path.subpath(0, path.getNameCount() - 1).toString());
+            remediatedPath.append("/");
+        }
+
+        final StringBuilder toRemediate = new StringBuilder(shaHex(node.getIdentifier().toString()));
+
+        remediatedPath.append(toRemediate);
+
+        if (locationHint.endsWith("/")) {
+            remediatedPath.append("/");
+        }
+
+        return remediatedPath.toString();
+    }
+
+}

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/FilenameValidator.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/FilenameValidator.java
@@ -33,29 +33,30 @@ public class FilenameValidator implements Validator {
     private int maxNameLength = 255;
 
     @Override
-    public ValidatorResult isValid(String fileName) {
-        Matcher matcher = pattern.matcher(fileName);
+    public ValidatorResult isValid(String pathComponent) {
+        Matcher matcher = pattern.matcher(pathComponent);
         ValidatorResult vr = new ValidatorResult();
         int v;
 
-        if(fileName.equals(".")){
+        if(pathComponent.equals(".")){
             vr.setResult(false);
-            vr.setMessage(" file name may not be \".\"");
-        } else if(fileName.equals("..")){
+            vr.setMessage(" path component may not be \".\"");
+        } else if(pathComponent.equals("..")){
             vr.setResult(false);
-            vr.setMessage(" file name may not be \"..\"");
-        } else if(containsAny(fileName,blacklist)){
+            vr.setMessage(" path component may not be \"..\"");
+        } else if(containsAny(pathComponent,blacklist)){
             vr.setResult(false);
-            vr.setMessage(" file name contains an illegal character: one or more of " + blacklist);
+            vr.setMessage(" path component contains an illegal character: one or more of " + blacklist);
         } else if(matcher.matches()){
             vr.setResult(false);
-            vr.setMessage(" file name is a Windows reserved file name");
-        } else if (fileName.length() > 255){
+            vr.setMessage(String.format("'%s' is a reserved path component", pathComponent));
+        } else if (pathComponent.length() > 255){
             vr.setResult(false);
-            vr.setMessage(" file name is too long, may not exceed " + maxNameLength +" characters");
-        } else if((v=containsIllegalUnicode(fileName)) >= 0){
+            vr.setMessage(" path component is too long, may not exceed " + maxNameLength +" characters");
+        } else if((v=containsIllegalUnicode(pathComponent)) >= 0){
             vr.setResult(false);
-            vr.setMessage(" file name contains an illegal unicode character at index " + v +"; this character may not be visible");
+            vr.setMessage(String.format(" path component '%s' contains an illegal unicode character at index %s; " +
+                    "this character may not be visible", pathComponent, v));
         } else {
             vr.setResult(true);
         }
@@ -82,6 +83,7 @@ public class FilenameValidator implements Validator {
             if (((Integer.parseInt("00", 16) <= j) && (j <= Integer.parseInt("1f", 16))) ||
                     (j >= Integer.parseInt("7f", 16))) { //0x7f is Delete
                 position = i;
+                break;
             }
         }
         return position;

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/ValidatorResult.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/ValidatorResult.java
@@ -26,6 +26,19 @@ public class ValidatorResult {
 
     boolean result;
 
+    public ValidatorResult() {
+
+    }
+
+    public ValidatorResult(boolean result) {
+        this.result = result;
+    }
+
+    public ValidatorResult(boolean result, String message) {
+        this.message = message;
+        this.result = result;
+    }
+
     public boolean getResult(){
         return result;
     };

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/BlacklistedCharacterMatcher.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/BlacklistedCharacterMatcher.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * A Hamcrest matcher that will match a subset of the illegal characters defined by
+ * <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">section 2.2.2.1</a>
+ * of the the Data Conservancy BagIt Profile.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ * @see <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">Data Conservancy BagIt Profile 1.0</a>
+ */
+public class BlacklistedCharacterMatcher extends BaseMatcher<Character> {
+
+    /**
+     * Returns {@code true} if the supplied character is one of the following:
+     * <dl>
+     *     <dt>"</dt>
+     *     <dd>Quotation Mark, 0x22</dd>
+     *     <dt>*</dt>
+     *     <dd>Asterisk, 0x2a</dd>
+     *     <dt>/</dt>
+     *     <dd>Solidus, 0x2f</dd>
+     *     <dt>:</dt>
+     *     <dd>Colon, 0x3a</dd>
+     *     <dt>&lt;</dt>
+     *     <dd>Less than sign, 0x3c</dd>
+     *     <dt>&gt;</dt>
+     *     <dd>Greater than sign, 0x3e</dd>
+     *     <dt>?</dt>
+     *     <dd>Question mark, 0x3f</dd>
+     *     <dt>\</dt>
+     *     <dd>Reverse Solidus, 0x5c</dd>
+     *     <dt>|</dt>
+     *     <dd>Vertical line, 0x7c</dd>
+     *     <dt>~</dt>
+     *     <dd>Tilde, 0x7e</dd>
+     * </dl>
+     *
+     * @param o the character to match
+     * @return true if the supplied character matches one of the documented characters
+     * @throws IllegalArgumentException if the supplied object is {@code null} or not a {@code Character}
+     */
+    @Override
+    public boolean matches(Object o) {
+        if (o == null) {
+            throw new IllegalArgumentException("Supplied Character must not be null.");
+        }
+
+        if (!(o instanceof Character)) {
+            throw new IllegalArgumentException("Supplied object must be an instanceof Character");
+        }
+
+        Character ch = (Character)o;
+
+        return ValidationUtils.isBlacklistedChar(ch);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+
+    }
+}

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/GenericCharacterMatcher.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/GenericCharacterMatcher.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * A Hamcrest {@link org.hamcrest.Matcher} which returns {@code true} if <em>any</em> of the characters supplied on
+ * construction {@link #matches(Object) matches} the supplied {@code Object}.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class GenericCharacterMatcher extends BaseMatcher<Character> {
+
+    private final CharSequence toMatch;
+
+    /**
+     * Constructs a new matcher which will {@link #matches(Object) match} any <em>one</em> of the supplied characters.
+     *
+     * @param toMatch an array of possible characters to match
+     */
+    public GenericCharacterMatcher(CharSequence toMatch) {
+        if (toMatch == null || toMatch.length() == 0) {
+            throw new IllegalArgumentException("CharSequence toMatch must not be empty or null.");
+        }
+        this.toMatch = toMatch;
+    }
+
+    /**
+     * Constructs a new matcher which will {@link #matches(Object) match} any <em>one</em> of the supplied characters.
+     *
+     * @param toMatch an array of possible characters to match
+     */
+    public GenericCharacterMatcher(char toMatch) {
+        this.toMatch = String.valueOf(toMatch);
+    }
+
+    /**
+     * Constructs a new matcher which will {@link #matches(Object) match} any <em>one</em> of the supplied characters.
+     *
+     * @param toMatch an array of possible characters to match
+     */
+    public GenericCharacterMatcher(char[] toMatch) {
+        if (toMatch == null || toMatch.length == 0) {
+            throw new IllegalArgumentException("char[] toMatch must not be empty or null.");
+        }
+        this.toMatch = String.valueOf(toMatch);
+    }
+
+    /**
+     * <p>
+     * Returns true if the supplied {@code Object} matches any <em>one</em> of the characters supplied at construction.
+     * </p>
+     * <p>
+     * <em>Implementation note:</em> the supplied {@code Object} <em>must</em> be an instance of {@code Character} or
+     * {@code CharSequence}.
+     * </p>
+     * {@inheritDoc}
+     *
+     * @param o the {@code Object} to match, which <em>must</em> be an instance if {@code Character}
+     * @return true if the {@code Object} to match is <em>one</em> of the characters supplied at construction
+     * @throws IllegalArgumentException if {@code o} is {@code null} or <em>is not</em> an instance of {@code Character}
+     *                                  or {@code CharSequence}
+     */
+    @Override
+    public boolean matches(Object o) {
+        if (o == null) {
+            throw new IllegalArgumentException("Supplied Character must not be null.");
+        }
+
+        if (!(o instanceof Character || o instanceof CharSequence)) {
+            throw new IllegalArgumentException("Supplied object must be an instanceof Character or CharSequence (was: " + o.getClass().getName() + ")");
+        }
+
+        if (o instanceof Character) {
+            char candidate = (char) o;
+            return toMatch.chars().filter(toMatch -> toMatch == candidate).findFirst().isPresent();
+        }
+        CharSequence candidates = (CharSequence) o;
+
+        return toMatch.chars().mapToObj(toMatch -> (char) toMatch)
+                .reduce(Boolean.FALSE,
+                        (result, toMatch) -> result ||
+                            candidates.chars().filter(candidate -> candidate == toMatch).findFirst().isPresent(),
+                        (one, two) -> one || two);
+    }
+
+    /**
+     * <em>Implementation note:</em> a no-op
+     * {@inheritDoc}
+     *
+     * @param description {@inheritDoc}
+     */
+    @Override
+    public void describeTo(Description description) {
+
+    }
+}

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/InvalidUtf8CharacterMatcher.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/InvalidUtf8CharacterMatcher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * A Hamcrest matcher that will match a subset of the illegal characters defined by
+ * <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">section 2.2.2.1</a>
+ * of the the Data Conservancy BagIt Profile.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ * @see <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">Data Conservancy BagIt Profile 1.0</a>
+ */
+public class InvalidUtf8CharacterMatcher extends BaseMatcher<Character> {
+
+    /**
+     * Returns {@code true} if the supplied character is between 0x00 and 0x1f (inclusive), or is greater than or equal
+     * to 0x7f.
+     * <p>
+     * This comports with §2.2.2.1 of the Data Conservancy BagIt Profile version 1.0
+     * </p>
+     *
+     * @param o the character to match
+     * @return true if the character matches
+     * @see <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">Data Conservancy BagIt Profile 1.0</a>
+     */
+    @Override
+    public boolean matches(Object o) {
+        if (o == null) {
+            throw new IllegalArgumentException("Supplied Character must not be null.");
+        }
+
+        if (!(o instanceof Character)) {
+            throw new IllegalArgumentException("Supplied object must be an instanceof Character");
+        }
+
+        Character ch = (Character)o;
+
+        return ValidationUtils.isInvalidUf8Char(ch);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+
+    }
+}

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/RemediationUtils.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/RemediationUtils.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.hamcrest.Matcher;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * Lower-level string examination and manipulation methods.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+class RemediationUtils {
+
+    /**
+     * Replaces the occurrence of each string in {@code stringsToReplace} with the {@code replacementChar}
+     * in the {@code original} string.
+     * <p>
+     * Examples:
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "baz" }
+     * result: "foo"
+     * The string "baz" never appears in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "o" }
+     * result: "fXX"
+     * The string "o" occurs twice in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "fo" }
+     * result: "XXo"
+     * The string "fo" occurs once in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "of" }
+     * result: "foo"
+     * The string "of" never appears in the original string
+     * </p>
+     *
+     * @param original the string to perform a replacement on
+     * @param replacementChar the character used to replace each character of a matching string
+     * @param stringsToReplace strings that may appear in the original string which are subject to replacement
+     * @return the {@code original} StringBuilder instance, which may have had a replacement operation performed on it
+     */
+    static StringBuilder replace(StringBuilder original, char replacementChar, String... stringsToReplace) {
+        return replaceStr(original, replacementChar, Arrays.stream(stringsToReplace));
+    }
+
+    /**
+     * Replaces the occurrence of each string in {@code stringsToReplace} with the {@code replacementChar}
+     * in the {@code original} string.
+     * <p>
+     * Examples:
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "baz" }
+     * result: "foo"
+     * The string "baz" never appears in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "o" }
+     * result: "fXX"
+     * The string "o" occurs twice in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "fo" }
+     * result: "XXo"
+     * The string "fo" occurs once in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "of" }
+     * result: "foo"
+     * The string "of" never appears in the original string
+     * </p>
+     *
+     * @param original the string to perform a replacement on
+     * @param replacementChar the character used to replace each character of a matching string
+     * @param stringsToReplace strings that may appear in the original string which are subject to replacement
+     * @return the {@code original} StringBuilder instance, which may have had a replacement operation performed on it
+     */
+    static StringBuilder replaceStr(StringBuilder original, char replacementChar, Stream<String> stringsToReplace) {
+        stringsToReplace.forEach(toReplace ->
+        {
+            int index = -1;
+            while ((index = original.indexOf(toReplace)) > -1) {
+                for (int replacementIndex = index; replacementIndex < (index + toReplace.length()); replacementIndex++) {
+                    original.setCharAt(replacementIndex, replacementChar);
+                }
+            }
+        });
+
+        return original;
+    }
+
+    /**
+     * Replaces the occurrence of each string in {@code stringsToReplace} with the {@code replacementChar}
+     * in the {@code original} string.
+     * <p>
+     * Examples:
+     * </p>
+     * <p>
+     * original: "foo"
+     * stringsToDelete: { "baz" }
+     * result: "foo"
+     * The string "baz" never appears in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * stringsToDelete: { "o" }
+     * result: "f"
+     * The string "o" occurs twice in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * stringsToDelete: { "fo" }
+     * result: "o"
+     * The string "fo" occurs once in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToDelete: { "of" }
+     * result: "foo"
+     * The string "of" never appears in the original string
+     * </p>
+     *
+     * @param original the string to perform a replacement on
+     * @param stringsToDelete strings that may appear in the original string which are subject to deletion
+     * @return the {@code original} StringBuilder instance, which may have had a deletion operation performed on it
+     */
+    static StringBuilder delete(StringBuilder original, String... stringsToDelete) {
+        for (String toDelete : stringsToDelete) {
+            int index = -1;
+            while ((index = original.indexOf(toDelete)) > -1) {
+                original.delete(index, index + toDelete.length());
+            }
+        }
+
+        return original;
+    }
+
+    /**
+     * Replaces each position in the original string with the replacement character.
+     *
+     * @param original the string to perform a replacement on
+     * @param replacementChar the character used to replace each position
+     * @param positionsToReplace the 0-based position(s) (index) in the original string to replace
+     * @return the {@code original} StringBuilder instance, which may have had replacement operations performed on it
+     * @throws IndexOutOfBoundsException if the position is not between 0 and original.length()
+     */
+    static StringBuilder replacePos(StringBuilder original, char replacementChar, Stream<Integer> positionsToReplace) {
+        positionsToReplace.forEach((index) -> original.setCharAt(index, replacementChar));
+        return original;
+    }
+
+    /**
+     * Tests the supplied {@code StringBuilder} for the presence of {@code strings}, and returns the positions of
+     * matching characters.
+     *
+     * @param toTest the {@code StringBuilder} being tested
+     * @param strings the strings being tested for
+     * @return a {@code Stream<Integer>} containing the positions (zero-indexed) of the characters matched by the
+     *         {@code strings}
+     */
+    static Stream<Integer> stringPositions(StringBuilder toTest, Stream<String> strings) {
+        if (toTest == null) {
+            throw new IllegalArgumentException("StringBuilder must not be null.");
+        }
+
+        if (strings == null) {
+            throw new IllegalArgumentException("Invalid strings must not be null");
+
+        }
+        Stream.Builder<Integer> positionStream = Stream.builder();
+        strings.forEach(invalidString -> {
+            int index = -1;
+            while ((index = toTest.indexOf(invalidString, index)) > -1) {
+                int endIndex = -1;
+                for (int i = index; i < (index + invalidString.length()); i++) {
+                    positionStream.accept(i);
+                    endIndex = i;
+                }
+                index = endIndex + 1;
+            }
+        });
+
+        return positionStream.build();
+    }
+
+    /**
+     * Applies each {@code Matcher} to each character of the {@code StringBuilder} and returns the positions of
+     * matching characters.
+     *
+     * @param toTest the {@code StringBuilder} being tested
+     * @param matchers the {@code Matcher}s applied to each character in the {@code StringBuilder}
+     * @return a {@code Stream<Integer>} containing the positions (zero-indexed) of characters matched by the
+     *         {@code matchers}
+     */
+    static Stream<Integer> matchPositions(StringBuilder toTest, Stream<Matcher<Character>> matchers) {
+        if (toTest == null) {
+            throw new IllegalArgumentException("StringBuilder must not be null.");
+        }
+
+        if (matchers == null) {
+            throw new IllegalArgumentException("Matchers must not be null");
+        }
+
+        Stream.Builder<Integer> positionStream = Stream.builder();
+
+        matchers.forEach(matcher -> {
+            for (int i = 0; i < toTest.length(); i++) {
+                if (matcher.matches(toTest.charAt(i))) {
+                    positionStream.accept(i);
+                }
+            }
+        });
+
+        return positionStream.build();
+    }
+}

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/SubstitutionRemediation.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/SubstitutionRemediation.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.hamcrest.Matcher;
+
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.dataconservancy.packaging.tool.impl.support.validation.RemediationUtils.matchPositions;
+
+/**
+ * Remediates strings by substituting a replacement character for unwanted characters or positions within a string.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class SubstitutionRemediation {
+
+    /**
+     * Replaces the occurrence of each string in {@code stringsToReplace} with the {@code replacementChar}
+     * in the {@code original} string.
+     * <p>
+     * Examples:
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "baz" }
+     * result: "foo"
+     * The string "baz" never appears in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "o" }
+     * result: "fXX"
+     * The string "o" occurs twice in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "fo" }
+     * result: "XXo"
+     * The string "fo" occurs once in the original string.
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "of" }
+     * result: "foo"
+     * The string "of" never appears in the original string
+     * </p>
+     *
+     * @param toRemediate the string to perform a replacement on
+     * @param replacementChar the character used to replace each character of a matching string
+     * @param stringsToReplace strings that may appear in the original string which are subject to replacement
+     * @return the {@code original} StringBuilder instance, which may have had a replacement operation performed on it
+     */
+    public StringBuilder remediateMatchingStrings(StringBuilder toRemediate, char replacementChar, String... stringsToReplace) {
+        return RemediationUtils.replace(toRemediate, replacementChar, stringsToReplace);
+    }
+
+    /**
+     * Replaces the occurrence of each character in {@code stringsToReplace} with the {@code replacementChar}
+     * if the replacement string is <em>equal to</em> the string to remediate.
+     * <p>
+     * Examples:
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "baz" }
+     * result: "foo"
+     * The string "baz" is not equal to "foo".
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "o" }
+     * result: "foo"
+     * The string "o" is not equal to "foo".
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "fo" }
+     * result: "foo"
+     * The string "fo" is not equal to "foo"
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "of" }
+     * result: "foo"
+     * The string "of" is not equal to "foo"
+     * </p>
+     * <p>
+     * original: "foo"
+     * replacementChar: 'X'
+     * stringsToReplace: { "foo" }
+     * result: "XXX"
+     * The strings are equal
+     * </p>
+     *
+     * @param toRemediate the string to perform a replacement on
+     * @param replacementChar the character used to replace each character of the string to remediate
+     * @param stringsToReplace strings that may equal to the original string which are subject to replacement
+     * @return the {@code original} StringBuilder instance, which may have had a replacement operation performed on it
+     */
+    public StringBuilder remediateEqualStrings(StringBuilder toRemediate, char replacementChar, String... stringsToReplace) {
+        String stringToRemediate = toRemediate.toString();
+        for (String stringToReplace : stringsToReplace) {
+            if (stringToRemediate.equals(stringToReplace)) {
+                RemediationUtils.replace(toRemediate, replacementChar, stringToReplace);
+                return toRemediate;
+            }
+        }
+
+        return toRemediate;
+    }
+
+    /**
+     * Replaces each character that matches in the original string with the replacement character.
+     *
+     * @param toRemediate the string to perform a replacement on
+     * @param replacementChar the character used to replace each invalid character
+     * @param invalidChMatcher matchers that are applied to each character in the string being remediated
+     * @return the {@code original} StringBuilder instance, which may have had replacement operations performed on it
+     * @throws IndexOutOfBoundsException if the position is not between 0 and original.length()
+     */
+    public StringBuilder remediateMatchingCharacters(StringBuilder toRemediate, char replacementChar, Stream<Matcher<Character>> invalidChMatcher) {
+        return RemediationUtils.replacePos(toRemediate, replacementChar, matchPositions(toRemediate, invalidChMatcher));
+    }
+
+    /**
+     * Replaces each character that matches the supplied regex in the original string with the replacement character.
+     *
+     * @param toRemediate the string to perform a replacement on
+     * @param replacementChar the character used to replace each character that matched the regular expression
+     * @param regexPattern a regular expression applied to the string being remediated
+     * @return the {@code original} StringBuilder instance, which may have had replacement operations performed on it
+     * @throws IndexOutOfBoundsException if the position is not between 0 and original.length()
+     */
+    public StringBuilder remediateMatchingStrings(StringBuilder toRemediate, char replacementChar, String regexPattern) {
+        Stream.Builder<Integer> positions = Stream.builder();
+        Pattern pattern = Pattern.compile(regexPattern);
+        java.util.regex.Matcher matcher = pattern.matcher(toRemediate);
+
+        int index = 0;
+        while (matcher.find(index)) {
+            MatchResult mr = matcher.toMatchResult();
+            for (int i = mr.start() ; i < mr.end(); i++) {
+                positions.accept(i);
+            }
+            index = mr.end();
+        }
+
+        return RemediationUtils.replacePos(toRemediate, replacementChar, positions.build());
+    }
+
+    /**
+     * Replaces each position in the original string with the replacement character.
+     *
+     * @param toRemediate the string to perform a replacement on
+     * @param replacementChar the character used to replace each position
+     * @param invalidPositions the 0-based position(s) (index) in the original string to replace
+     * @return the {@code original} StringBuilder instance, which may have had replacement operations performed on it
+     * @throws IndexOutOfBoundsException if the position is not between 0 and original.length()
+     */
+    public StringBuilder remediatePositions(StringBuilder toRemediate, char replacementChar, Stream<Integer> invalidPositions) {
+        return RemediationUtils.replacePos(toRemediate, replacementChar, invalidPositions);
+    }
+
+}

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/TruncationRemediation.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/TruncationRemediation.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.dataconservancy.packaging.tool.api.generator.PackageResourceType;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Truncates strings that are longer than the specified number of characters.  When a truncation takes place, the
+ * truncation character, {@code X}, is substituted in place of truncated characters.  The solidus ({@code /}, 0x2f) and
+ * full stop ({@code .}, 0x2e) are never truncated.  Strings may be truncated from the
+ * {@link Strategy#LEADING_SUBSTITUTION beginning} or {@link Strategy#TRAILING_SUBSTITUTION ending} of the supplied
+ * string.  If there are portions of a string that the caller never wishes to be truncated (e.g. {@link PackageResourceType
+ * directories reserved} by the BagIt specification and profile), then those portions should <em>not</em> be passed to
+ * this class for remediation.  If a string <em>cannot</em> be truncated to the specified limit, a
+ * {@code RuntimeException} is thrown.
+ * <p>
+ * According to the Data Conservancy BagIt Profile 1.0, the paths within a bag may not be longer than 1024 characters,
+ * and individual <em>path components</em> may not be longer than 255 characters.  Path components are delimited by
+ * the forward slash (a.k.a solidus: {@code /}, 0x2f).  Example paths that conform to the Profile include:
+ * </p>
+ * <dl>
+ *     <dt>data/bin/path/to/binary/file.bin</dt>
+ *     <dd>a relative path with six <em>path components</em>, each component less than 255 characters, and an overall
+ *         length less than 1025 characters.</dd>
+ *     <dt>/data/bin/path/to/binary/file.bin</dt>
+ *     <dd>an absolute form of the same path, still containing six path components.</dd>
+ *     <dt>META-INF/org.dataconservancy.packaging/PKG-INFO/ORE-REM/manifest.rdf</dt>
+ *     <dd>another example path composed of five path components</dd>
+ *     <dt>/data</dt>
+ *     <dd>an absolute path composed of a single path component</dd>
+ *     <dt>bag-info.txt</dt>
+ *     <dd>a single path component that appears to be a file name</dd>
+ * </dl>
+ * <p>
+ * This class provides special consideration to strings being truncated.  That is to say, the semantic of the string
+ * supplied for remediation is considered to be a file path, which may be absolute (beginning with the solidus) or
+ * relative.  Special consideration is given to two characters common in file paths: the solidus ({@code /}, 0x2f) and
+ * the full stop ({@code .}, 0x2e).  The solidus is considered to be a path separator, and the full stop is often used
+ * to delimit a file <em>name</em> from the <em>extension</em>.  Accordingly, these characters are <em>not</em> subject
+ * to truncation.
+ * </p>
+ *
+ * @see <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">Data Conservancy
+ *      BagIt Profile 1.0 §2.2.2.1</a>
+ */
+public class TruncationRemediation {
+
+    /**
+     * Character that serves to separate <em>path components</em>
+     */
+    static final char PATH_SEPARATOR = '/';
+
+    /**
+     * Character that serves to separate a file <em>name</em> from a file name <em>extension</em>
+     */
+    static final char EXT_SEPARATOR = '.';
+
+    /**
+     * Character inserted into a remediated string signaling that a truncation has occurred.
+     */
+    static final char TRUNCATION_CHAR = 'X';
+
+    /**
+     * Characters that must not be truncated (i.e. they must be preserved in the remediated string)
+     */
+    static final char[] RESERVED_CHARS = {PATH_SEPARATOR, EXT_SEPARATOR};
+
+    private GenericCharacterMatcher reservedCharacterMatcher = new GenericCharacterMatcher(RESERVED_CHARS);
+
+    /**
+     * A strategy used to perform truncation
+     */
+    public enum Strategy {
+
+        /**
+         * Truncates characters starting with those at the beginning of the string
+         */
+        LEADING_SUBSTITUTION,
+
+        /**
+         * Truncates characters starting with those at the end of the string
+         */
+        TRAILING_SUBSTITUTION,
+    }
+
+    /**
+     * Remediates the supplied string by truncating it to the specified number of characters.  Characters will be
+     * truncated according to the supplied {@link Strategy}.  If the string is already within the supplied limit, the
+     * string is returned unaltered.  If the string cannot be truncated to the specified limit, a
+     * {@code RuntimeException} is thrown.
+     *
+     * @param toRemediate the string to be remediated to the specified {@code length}
+     * @param limit the length of the remediated string
+     * @param strategy determines which characters are considered for remediation first
+     * @return the remediate string, of length {@code limit}
+     * @throws RuntimeException if the supplied string cannot be truncated to the specified length
+     * @throws IllegalArgumentException if the limit is out of bounds (less than 1) or if any argument is {@code null}.
+     */
+    public String remediate(StringBuilder toRemediate, int limit, Strategy strategy) {
+        if (toRemediate == null) {
+            throw new IllegalArgumentException("The StringBuilder to remediate must not be null.");
+        }
+
+        if (strategy == null) {
+            throw new IllegalArgumentException("The remediation Strategy must not be null.");
+        }
+
+        if (limit < 1) {
+            throw new IllegalArgumentException("Remediation limit must be greater than 0.");
+        }
+
+        if (toRemediate.length() <= limit) {
+            return toRemediate.toString();
+        }
+
+        final int ignoredCharacterCount = toRemediate.length() - limit;
+        final AtomicInteger ignoredCharactersRemaining = new AtomicInteger(ignoredCharacterCount);
+        final AtomicReference<STATE> state = new AtomicReference<>(STATE.INIT);
+
+        switch (strategy) {
+            case LEADING_SUBSTITUTION:
+                toRemediate = toRemediate.chars()
+                        .sequential()
+                        .mapToObj(ch -> ((char) ch))
+                        .reduce(new StringBuilder(),
+                                (result, element) -> {
+                                    switch (state.get()) {
+                                        case INIT:
+                                            if (reservedCharacterMatcher.matches(element)) {
+                                                result.append(element);
+                                            } else {
+                                                result.append(TRUNCATION_CHAR);
+                                            }
+                                            state.set(STATE.IGNORE);
+                                            break;
+                                        case IGNORE:
+                                            if (reservedCharacterMatcher.matches(element)) {
+                                                result.append(element);
+                                                break;
+                                            }
+
+                                            if (reservedCharacterMatcher.matches(result.charAt(result.length() - 1))
+                                                    && ignoredCharactersRemaining.get() > 0) {
+                                                result.append(TRUNCATION_CHAR);
+                                                break;
+                                            }
+
+                                            if (ignoredCharactersRemaining.getAndDecrement() <= 0) {
+                                                result.append(element);
+                                                state.set(STATE.PASS_THROUGH);
+                                            }
+
+                                            break;
+                                        case PASS_THROUGH:
+                                            result.append(element);
+                                            break;
+                                        default:
+                                            throw new IllegalStateException("Unknown state!");
+                                    }
+                                    return result;
+                                },
+                                StringBuilder::append);
+                break;
+            case TRAILING_SUBSTITUTION:
+                StringBuilder result = toRemediate.reverse().chars()
+                        .sequential()
+                        .mapToObj(ch -> (char) ch)
+                        .reduce(new StringBuilder(),
+                                (builder, ch) -> {
+                                    switch (state.get()) {
+                                        case INIT:
+                                            if (reservedCharacterMatcher.matches(ch)) {
+                                                builder.append(ch);
+                                            } else if (ignoredCharactersRemaining.get() > 0) {
+                                                builder.append(TRUNCATION_CHAR);
+                                                state.set(STATE.IGNORE);
+                                            } else {
+                                                builder.append(ch);
+                                                state.set(STATE.PASS_THROUGH);
+                                            }
+                                            break;
+                                        case IGNORE:
+                                            if (reservedCharacterMatcher.matches(ch)) {
+                                                builder.append(ch);
+                                            } else if (reservedCharacterMatcher.matches(builder.charAt(builder.length() - 1))) {
+                                                builder.append(TRUNCATION_CHAR);
+                                            } else if (ignoredCharactersRemaining.get() == 0) {
+                                                builder.append(ch);
+                                                state.set(STATE.PASS_THROUGH);
+                                            } else {
+                                                ignoredCharactersRemaining.getAndDecrement();
+                                            }
+                                            break;
+                                        case PASS_THROUGH:
+                                            builder.append(ch);
+                                            break;
+                                        default:
+                                            throw new IllegalStateException("Unknown state!");
+                                    }
+
+                                    return builder;
+                                },
+                                StringBuilder::append);
+                toRemediate = result.reverse();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown truncation remediation strategy!");
+        }
+
+        final String result = toRemediate.toString();
+        if (result.length() > limit) {
+            throw new RuntimeException("Failed to limit remediated string to " + limit + " characters (actual remediated length: " + result.length() + " characters): '" + result + "'");
+        }
+
+        return result;
+    }
+
+    private enum STATE {
+        INIT,
+        IGNORE,
+        PASS_THROUGH
+    }
+
+}

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/ValidationUtils.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/support/validation/ValidationUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+class ValidationUtils {
+
+    /**
+     * Returns {@code true} if the supplied character is between 0x00 and 0x1f (inclusive), or is greater than or equal
+     * to 0x7f.
+     * <p>
+     * This comports with §2.2.2.1 of the Data Conservancy BagIt Profile version 1.0
+     * </p>
+     *
+     * @param ch the character
+     * @return true if the character matches
+     * @see <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">Data Conservancy BagIt Profile 1.0</a>
+     */
+    static boolean isInvalidUf8Char(char ch) {
+        if (((Integer.parseInt("00", 16) <= ch) && (ch <= Integer.parseInt("1f", 16))) ||
+                (ch >= Integer.parseInt("7f", 16))) { //0x7f is Delete
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if the supplied character is a:
+     * <dl>
+     *     <dt>"</dt>
+     *     <dd>Quotation Mark, 0x22</dd>
+     *     <dt>*</dt>
+     *     <dd>Asterisk, 0x2a</dd>
+     *     <dt>/</dt>
+     *     <dd>Solidus, 0x2f</dd>
+     *     <dt>:</dt>
+     *     <dd>Colon, 0x3a</dd>
+     *     <dt>&lt;</dt>
+     *     <dd>Less than sign, 0x3c</dd>
+     *     <dt>&gt;</dt>
+     *     <dd>Greater than sign, 0x3e</dd>
+     *     <dt>?</dt>
+     *     <dd>Question mark, 0x3f</dd>
+     *     <dt>\</dt>
+     *     <dd>Reverse Solidus, 0x5c</dd>
+     *     <dt>|</dt>
+     *     <dd>Vertical line, 0x7c</dd>
+     *     <dt>~</dt>
+     *     <dd>Tilde, 0x7e</dd>
+     * </dl>
+     * <p>
+     * This comports with §2.2.2.1 of the Data Conservancy BagIt Profile version 1.0
+     * </p>
+     *
+     * @param ch the character
+     * @return true if the character matches
+     * @see <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">Data Conservancy BagIt Profile 1.0</a>
+     */
+    static boolean isBlacklistedChar(char ch) {
+        return ch == (char) 0x22  ||  // "
+                ch == (char) 0x2a ||  // *
+                ch == (char) 0x2f ||  // /
+                ch == (char) 0x3a ||  // :
+                ch == (char) 0x3c ||  // <
+                ch == (char) 0x3e ||  // >
+                ch == (char) 0x3f ||  // ?
+                ch == (char) 0x5c ||  // \
+                ch == (char) 0x7c ||  // |
+                ch == (char) 0x7e;    // ~
+    }
+}

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssemblerTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssemblerTest.java
@@ -15,7 +15,9 @@
  */
 package org.dataconservancy.packaging.tool.impl.generator;
 
+import org.apache.commons.io.input.NullInputStream;
 import org.dataconservancy.packaging.tool.api.PackagingFormat;
+import org.dataconservancy.packaging.tool.api.generator.PackageResourceType;
 import org.junit.Assert;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -30,7 +32,6 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.IOUtils;
 
 import org.dataconservancy.packaging.tool.api.Package;
-import org.dataconservancy.packaging.tool.api.generator.PackageResourceType;
 import org.dataconservancy.packaging.tool.model.BagItParameterNames;
 import org.dataconservancy.packaging.tool.model.GeneralParameterNames;
 import org.dataconservancy.packaging.tool.model.PackageGenerationParameters;
@@ -75,6 +76,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({ "classpath:/test-applicationContext.xml"})
 public class BagItPackageAssemblerTest {
@@ -231,46 +234,28 @@ public class BagItPackageAssemblerTest {
     }
 
     @Test
-    public void testReserveURIFailsForBadDataFile(){
-        String filePath = "bad~file:name";
-        expected.expect(PackageToolException.class);
-        expected.expectMessage("One or more of the files provided to the package assembler has an invalid file name.");
-        underTest.reserveResource(filePath, PackageResourceType.DATA);
+    public void testReserveDuplicateResource() throws Exception {
+        underTest.reserveResource("path/to/file.txt", PackageResourceType.DATA);
+        try {
+            underTest.reserveResource("path/to/file.txt", PackageResourceType.DATA);
+            fail("Expected a PackageToolException to be thrown!");
+        } catch (PackageToolException e) {
+            // expected
+            assertEquals(409, e.getCode());
+        }
     }
 
     @Test
-    public void testReserveURIFailsForBadMetadataDataFile(){
-        String filePath = "bad~file:name";
-        expected.expect(PackageToolException.class);
-        expected.expectMessage("One or more of the files provided to the package assembler has an invalid file name.");
-        underTest.reserveResource(filePath, PackageResourceType.METADATA);
+    public void testCreateDuplicateResource() throws Exception {
+        underTest.createResource("path/to/file.txt", PackageResourceType.DATA, new NullInputStream(-1));
+        try {
+            underTest.createResource("path/to/file.txt", PackageResourceType.DATA, new NullInputStream(-1));
+            fail("Expected a PackageToolException to be thrown!");
+        } catch (PackageToolException e) {
+            // expected
+            assertEquals(409, e.getCode());
+        }
     }
-
-    @Test
-    public void testReserveURIFailsForBadReMFile(){
-        String filePath = "bad~file:name";
-        expected.expect(PackageToolException.class);
-        expected.expectMessage("One or more of the files provided to the package assembler has an invalid file name.");
-        underTest.reserveResource(filePath, PackageResourceType.ORE_REM);
-    }
-
-    @Test
-    public void testReserveURIFailsForBadOntologyFile(){
-        String filePath = "bad~file:name";
-        expected.expect(PackageToolException.class);
-        expected.expectMessage("One or more of the files provided to the package assembler has an invalid file name.");
-        underTest.reserveResource(filePath, PackageResourceType.ONTOLOGY);
-    }
-
-    @Test
-    public void testReserveURIFailsForBadStateFile(){
-        String filePath = "bad~file:name";
-        expected.expect(PackageToolException.class);
-        expected.expectMessage("One or more of the files provided to the package assembler has an invalid file name.");
-        underTest.reserveResource(filePath, PackageResourceType.PACKAGE_STATE);
-    }
-
-
 
     @Test
     public void testPutResource() throws IOException {

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/PathTestingUtils.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/PathTestingUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.generator;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+/**
+ * Utility methods for creating path components.  Useful when testing remediation of long paths.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class PathTestingUtils {
+    /**
+     * Creates {@code componentCount} path components.  Each path component will be the specified {@code length}.  The
+     * components will be joined together by {@code delimiter}.
+     *
+     * @param delimiter
+     * @param componentCount
+     * @param length
+     * @return
+     */
+    public static String components(String delimiter, int componentCount, int length) {
+        if (length < 1) {
+            throw new IllegalArgumentException("Length must be a positive integer");
+        }
+
+        if (componentCount < 1) {
+            throw new IllegalArgumentException("Component count must be a positive integer");
+        }
+
+        if (delimiter == null) {
+            throw new IllegalArgumentException("Delimiter string must not be null (but it may be empty)");
+        }
+
+        StringBuilder componentString = new StringBuilder();
+
+        for (int i = 0; i < componentCount; i++) {
+            componentString.append(stringOf(length));
+            if ((i + 1) < componentCount) {
+                componentString.append(delimiter);
+            }
+        }
+
+        return componentString.toString();
+    }
+
+    /**
+     * Builds a string of specified length, containing <em>only</em> numbers (0-9) or letters (a-z, A-Z).
+     *
+     * @param length number of characters in the generated string
+     * @return a string of {@code length} characters, containing <em>only</em> alphanumerics.
+     */
+    public static String stringOf(final int length) {
+        if (length < 1) {
+            throw new IllegalArgumentException("Length must be a positive integer.");
+        }
+        // valid 0x30 - 0x39 0-9 (10 characters, offset 0-9)
+        // valid 0x41 - 0x5a A-Z (26 characters, offset 10-35)
+        // valid 0x61 - 0x7a a-z (26 characters, offset 36-61)
+        //                       (62 total, offset 0-61)
+
+        final Random random = new Random();
+        final StringBuilder str = random.ints(length, 0, 62)
+                .mapToObj(offset -> {
+                    int base;
+                    int index;
+                    if (offset < 10) {  // 0-9 (0x30 - 0x39)
+                        base = 48; // 0x30;
+                        index = base + offset;  // min: 48, max: 57 (0x39)
+                    } else if (offset < 36) { // A-Z (0x41 - 0x5a)
+                        base = 65; // 0x41;
+                        index = base + (offset - 10);  // min: 65 max: 90 (0x5a)
+                    } else {
+                        base = 97; // 0x61;
+                        index = base + (offset - 36);  // min: 97 max: 122 (0x7a)
+                    }
+
+                    return Character.valueOf((char) index);
+                })
+                .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append);
+
+        return str.toString();
+    }
+
+    /**
+     * Joins strings with the specified delimiter.
+     *
+     * @param delimiter
+     * @param strings
+     * @return
+     */
+    public static String join(String delimiter, String... strings) {
+        if (delimiter == null) {
+            throw new IllegalArgumentException("Delimter must not be null (but may be empty)");
+        }
+        return Arrays.stream(strings).collect(Collectors.joining(delimiter, "", ""));
+    }
+
+    /**
+     * Joins strings with the specified delimiter.  The string will be prefixed with the delimiter.
+     *
+     * @param delimiter
+     * @param strings
+     * @return
+     */
+    public static String joinAbsolutely(String delimiter, String... strings) {
+        if (delimiter == null) {
+            throw new IllegalArgumentException("Delimter must not be null (but may be empty)");
+        }
+        return Arrays.stream(strings).collect(Collectors.joining(delimiter, delimiter, ""));
+    }
+}

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/RemediationUtilTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/RemediationUtilTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.generator;
+
+import org.dataconservancy.packaging.tool.impl.SimpleURIGenerator;
+import org.dataconservancy.packaging.tool.impl.URIGenerator;
+import org.dataconservancy.packaging.tool.model.ipm.Node;
+import org.junit.Test;
+
+import static org.apache.commons.codec.digest.DigestUtils.shaHex;
+import static org.dataconservancy.packaging.tool.api.generator.PackageResourceType.DATA;
+import static org.dataconservancy.packaging.tool.impl.generator.PathTestingUtils.components;
+import static org.dataconservancy.packaging.tool.impl.generator.PathTestingUtils.join;
+import static org.dataconservancy.packaging.tool.impl.generator.PathTestingUtils.stringOf;
+import static org.dataconservancy.packaging.tool.impl.generator.RemediationUtil.remediatePath;
+import static org.dataconservancy.packaging.tool.impl.generator.RemediationUtil.unique;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class RemediationUtilTest {
+
+    private static final String PROFILE_ID = "http://dataconservancy.org/formats/data-conservancy-pkg-1.0";
+
+    private String dataPathComponent = join("/", DATA.getRelativePackageLocation());
+
+    private URIGenerator uriGen = new SimpleURIGenerator();
+
+    @Test
+    public void testIllegalUtf8CharacterRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "hXllo wXrld!.txt"),
+                remediatePath(join("/", dataPathComponent, "héllo wörld!.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testIllegalBlacklistedCharacterRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "README.txtX"),
+                remediatePath(join("/", dataPathComponent, "README.txt~"), PROFILE_ID));
+    }
+
+    @Test
+    public void testIllegalPathComponentLengthRemediation() throws Exception {
+        final String illegalComponent = stringOf(256);
+        final String illegalPath = join("/", dataPathComponent, illegalComponent);
+        assertEquals(illegalPath.length() - 1, remediatePath(illegalPath, PROFILE_ID).length());
+    }
+
+    @Test
+    public void testIllegalPathLengthRemediation() throws Exception {
+        final String illegalComponents = components("/", 4, 255);
+        final String illegalPath = join("/", dataPathComponent, illegalComponents);
+        assertTrue(illegalPath.length() > 1024);
+        assertEquals(1024, remediatePath(illegalPath, PROFILE_ID).length());
+    }
+
+    @Test
+    public void testReservedWindowsFilenameRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXX"),
+                remediatePath(join("/", dataPathComponent, "CON"), PROFILE_ID));
+    }
+
+    @Test
+    public void testReservedWindowsPathRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXX", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "CON", "file.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testReservedWindowsFilenameWithCounterRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXXX"),
+                remediatePath(join("/", dataPathComponent, "LPT9"), PROFILE_ID));
+    }
+
+    @Test
+    public void testReservedWindowsPathWithCounterRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXXX", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "LPT9", "file.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testReservedWindowsFilenameWithExtensionRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXXXXXX"),
+                remediatePath(join("/", dataPathComponent, "CON.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testReservedWindowsPathWithExtensionRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXXXXXX", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "CON.txt", "file.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testNonGreedyWindowsPathRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXX", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "COM", "file.txt"), PROFILE_ID));
+
+        assertEquals(join("/", dataPathComponent, "COMPACT", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "COMPACT", "file.txt"), PROFILE_ID));
+
+        assertEquals(join("/", dataPathComponent, "MYCOM", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "MYCOM", "file.txt"), PROFILE_ID));
+
+        assertEquals(join("/", dataPathComponent, "RECOMPOSE", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "RECOMPOSE", "file.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testNonGreedyWindowsFilenameRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XXX"),
+                remediatePath(join("/", dataPathComponent, "COM"), PROFILE_ID));
+
+        assertEquals(join("/", dataPathComponent, "COMPACT"),
+                remediatePath(join("/", dataPathComponent, "COMPACT"), PROFILE_ID));
+
+        assertEquals(join("/", dataPathComponent, "MYCOM"),
+                remediatePath(join("/", dataPathComponent, "MYCOM"), PROFILE_ID));
+
+        assertEquals(join("/", dataPathComponent, "RECOMPOSE"),
+                remediatePath(join("/", dataPathComponent, "RECOMPOSE"), PROFILE_ID));
+    }
+
+    @Test
+    public void testDotDotPathComponentRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XX", "file.txt"),
+                remediatePath(join("/", dataPathComponent, "..", "file.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testDotPathComponentRemediation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "X", "file.txt"),
+                remediatePath(join("/", dataPathComponent, ".", "file.txt"), PROFILE_ID));
+    }
+
+    @Test
+    public void testDotDotFilenameRemedation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "XX"),
+                remediatePath(join("/", dataPathComponent, ".."), PROFILE_ID));
+
+    }
+
+    @Test
+    public void testDotFilenameRemedation() throws Exception {
+        assertEquals(join("/", dataPathComponent, "X"),
+                remediatePath(join("/", dataPathComponent, "."), PROFILE_ID));
+    }
+
+    @Test
+    public void testUniqueAbsolutePathWithFile() throws Exception {
+        Node n = new Node(uriGen.generateNodeURI());
+        String hint =     "/path/to/file.txt";
+        String expected = "/path/to/" + shaHex(n.getIdentifier().toString());
+
+        assertEquals(expected, unique(n, hint));
+    }
+
+    @Test
+    public void testUniqueRelativePathWithFile() throws Exception {
+        Node n = new Node(uriGen.generateNodeURI());
+        String hint =     "path/to/file.txt";
+        String expected = "path/to/" + shaHex(n.getIdentifier().toString());
+
+        assertEquals(expected, unique(n, hint));
+    }
+
+    @Test
+    public void testUniqueAbsolutePathWithDir() throws Exception {
+        Node n = new Node(uriGen.generateNodeURI());
+        String hint =     "/path/to/directory/";
+        String expected = "/path/to/" + shaHex(n.getIdentifier().toString()) + "/";
+
+        assertEquals(expected, unique(n, hint));
+    }
+
+    @Test
+    public void testUniqueRelativePathWithDir() throws Exception {
+        Node n = new Node(uriGen.generateNodeURI());
+        String hint =     "path/to/directory/";
+        String expected = "path/to/" + shaHex(n.getIdentifier().toString()) + "/";
+
+        assertEquals(expected, unique(n, hint));
+    }
+
+    @Test
+    public void testUniqueSingleFile() throws Exception {
+        Node n = new Node(uriGen.generateNodeURI());
+        String hint =     "file.txt";
+        String expected = shaHex(n.getIdentifier().toString());
+
+        assertEquals(expected, unique(n, hint));
+    }
+}

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/GenericCharacterMatcherTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/GenericCharacterMatcherTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class GenericCharacterMatcherTest {
+
+    @Test
+    public void testStringMatchesReservedCharacter() throws Exception {
+        char reserved = 'f';
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        String toTest = "foo";
+
+        assertTrue(underTest.matches(toTest));
+    }
+
+    @Test
+    public void testStringNoMatchReservedCharacter() throws Exception {
+        char reserved = 'f';
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        String toTest = "bar";
+
+        assertFalse(underTest.matches(toTest));
+    }
+
+    @Test
+    public void testCharacterMatchesReservedCharacter() throws Exception {
+        char reserved = 'f';
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        char toTest = 'f';
+
+        assertTrue(underTest.matches(toTest));
+    }
+
+    @Test
+    public void testCharacterNoMatchReservedCharacter() throws Exception {
+        char reserved = 'f';
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        char toTest = 'b';
+
+        assertFalse(underTest.matches(toTest));
+    }
+
+    @Test
+    public void testStringMatchesReservedString() throws Exception {
+        String reserved = "fb";
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        String toTest = "foo";
+
+        assertTrue(underTest.matches(toTest));
+    }
+
+    @Test
+    public void testStringNoMatchesReservedString() throws Exception {
+        String reserved = "foo";
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        String toTest = "bar";
+
+        assertFalse(underTest.matches(toTest));
+    }
+
+    @Test
+    public void testStringLastCharacterMatchesReservedString() throws Exception {
+        String reserved = "for";
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        String toTest = "bar";
+
+        assertTrue(underTest.matches(toTest));
+    }
+
+    @Test
+    public void testStringACharacterMatchesReservedString() throws Exception {
+        String reserved = "for";
+        GenericCharacterMatcher underTest = new GenericCharacterMatcher(reserved);
+        String toTest = "barn";
+
+        assertTrue(underTest.matches(toTest));
+    }
+}

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/InvalidUtf8CharacterMatcherTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/InvalidUtf8CharacterMatcherTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class InvalidUtf8CharacterMatcherTest {
+
+    private InvalidUtf8CharacterMatcher underTest = new InvalidUtf8CharacterMatcher();
+
+    @Test
+    public void testMatchesValidCharacter() throws Exception {
+        assertFalse(underTest.matches('a'));
+    }
+
+    @Test
+    public void testMatchesInvalidCharacter() throws Exception {
+        assertTrue(underTest.matches('\u00e9')); // é
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMatchesString() throws Exception {
+        underTest.matches("a");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMatchesNull() throws Exception {
+        underTest.matches(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMatchesInt() throws Exception {
+        underTest.matches((int) 'a');
+    }
+}

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/RemediationUtilsTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/RemediationUtilsTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.dataconservancy.packaging.tool.impl.support.validation.RemediationUtils.delete;
+import static org.dataconservancy.packaging.tool.impl.support.validation.RemediationUtils.replace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class RemediationUtilsTest {
+
+    /**
+     * "héllö wörld!"
+     * <p>
+     * Invalid indexes are 1, 4, 7
+     * </p>
+     * <p>
+     * Contains illegal characters per
+     * <a href="http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.1">version 1.0 of
+     * the DC BagIt profile</a>
+     */
+    private static final String ILLEGAL_CHARS = "h\u00e9ll\u00F6 w\u00f6rld!";
+
+    @Test
+    public void testSingleCharSingleOccurrence() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the laiy dog";
+
+        assertEquals(expected,
+                replace(new StringBuilder(initial), 'i', "z").toString());
+
+    }
+
+    @Test
+    public void testSingleCharMultipleOccurrence() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "Thq quick brown fox jumpqd ovqr thq lazy dog";
+
+        assertEquals(expected,
+                replace(new StringBuilder(initial), 'q', "e").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersSingleOccurrence() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the lazy xxx";
+
+        assertEquals(expected,
+                replace(new StringBuilder(initial), 'x', "dog").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersMultipleOccurrence() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over xxe lazy dog";
+
+        assertEquals(expected,
+                replace(new StringBuilder(initial), 'x', "th").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersMultipleOccurrenceMultipleStrings() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over xxe lazy xxx";
+
+        assertEquals(expected,
+                replace(new StringBuilder(initial), 'x', "th", "dog").toString());
+    }
+
+    @Test
+    public void testSingleCharSingleOccurrenceDelete() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the lay dog";
+
+        assertEquals(expected,
+                RemediationUtils.delete(new StringBuilder(initial), "z").toString());
+
+    }
+
+    @Test
+    public void testSingleCharMultipleOccurrenceDelete() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "Th quick brown fox jumpd ovr th lazy dog";
+
+        assertEquals(expected,
+                RemediationUtils.delete(new StringBuilder(initial), "e").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersSingleOccurrenceDelete() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the lazy ";
+
+        assertEquals(expected,
+                RemediationUtils.delete(new StringBuilder(initial), "dog").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersMultipleOccurrenceDelete() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over e lazy dog";
+
+        assertEquals(expected,
+                RemediationUtils.delete(new StringBuilder(initial), "th").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersMultipleOccurrenceMultipleStringsDelete() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over e lazy ";
+
+        assertEquals(expected,
+                RemediationUtils.delete(new StringBuilder(initial),"th", "dog").toString());
+    }
+
+    @Test
+    public void testReplacementJavadocExamples() throws Exception {
+        assertEquals("foo",
+                replace(new StringBuilder("foo"), 'X', "baz").toString());
+
+        assertEquals("fXX",
+                replace(new StringBuilder("foo"), 'X', "o").toString());
+
+        assertEquals("foo",
+                replace(new StringBuilder("foo"), 'X', "of").toString());
+
+        assertEquals("XXo",
+                replace(new StringBuilder("foo"), 'X', "fo").toString());
+    }
+
+    @Test
+    public void testDeletionJavadocExamples() throws Exception {
+        assertEquals("foo",
+                delete(new StringBuilder("foo"), "baz").toString());
+
+        assertEquals("f",
+                delete(new StringBuilder("foo"), "o").toString());
+
+        assertEquals("foo",
+                delete(new StringBuilder("foo"),"of").toString());
+
+        assertEquals("o",
+                delete(new StringBuilder("foo"), "fo").toString());
+    }
+
+    @Test
+    public void testPositionFound() throws Exception {
+        Stream<Integer> invalidPositions = RemediationUtils.stringPositions(new StringBuilder("abc"), Stream.of("a"));
+        assertEquals(1, invalidPositions.count());
+        invalidPositions = RemediationUtils.stringPositions(new StringBuilder("abc"), Stream.of("a"));
+        assertEquals(0, (long)invalidPositions.findFirst().get());
+    }
+
+    @Test
+    public void testPositionNotFound() throws Exception {
+        Stream<Integer> invalidPositions = RemediationUtils.stringPositions(new StringBuilder("abc"), Stream.of("z"));
+        assertEquals(0, invalidPositions.count());
+        invalidPositions = RemediationUtils.stringPositions(new StringBuilder("abc"), Stream.of("z"));
+        assertFalse(invalidPositions.findFirst().isPresent());
+    }
+
+    @Test
+    public void testPositionsMultiple() throws Exception {
+        Stream<Integer> invalidPositions = RemediationUtils.stringPositions(new StringBuilder("abc"), Stream.of("a", "c"));
+
+        final AtomicInteger index = new AtomicInteger(0);
+        long found = invalidPositions.peek(pos -> {
+            if (index.get() == 0) {
+                assertEquals(0, (long)pos);
+            }
+            if (index.get() == 1) {
+                assertEquals(2, (long)pos);
+            }
+            index.getAndIncrement();
+        }).count();
+
+        assertEquals(2, found);
+    }
+
+    @Test
+    public void testPositionsUtf8InvalidCharacters() throws Exception {
+        Stream<Integer> invalidPositions = RemediationUtils.matchPositions(new StringBuilder(ILLEGAL_CHARS), Stream.of(new InvalidUtf8CharacterMatcher()));
+
+        final AtomicInteger index = new AtomicInteger(0);
+        long found = invalidPositions.peek(pos -> {
+            if (index.get() == 0) {
+                assertEquals(1, (long)pos);
+            }
+            if (index.get() == 1) {
+                assertEquals(4, (long)pos);
+            }
+            if (index.get() == 2) {
+                assertEquals(7, (long)pos);
+            }
+            index.getAndIncrement();
+        }).count();
+
+        assertEquals(3, found);
+    }
+}

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/SubstitutionRemediationTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/SubstitutionRemediationTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Test;
+
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class SubstitutionRemediationTest {
+
+    private SubstitutionRemediation underTest = new SubstitutionRemediation();
+
+    @Test
+    public void testSingleCharSingleOccurrenceUsingMatchingStrings() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the laiy dog";
+
+        assertEquals(expected,
+                underTest.remediateMatchingStrings(new StringBuilder(initial), 'i', "z").toString());
+    }
+
+    @Test
+    public void testSingleCharSingleOccurrenceUsingPositions() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the laiy dog";
+
+        assertEquals(expected,
+                underTest.remediatePositions(new StringBuilder(initial), 'i', Stream.of(38)).toString());
+    }
+
+    @Test
+    public void testSingleCharSingleOccurrenceUsingMatcher() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the laiy dog";
+
+        assertEquals(expected,
+                underTest.remediateMatchingCharacters(new StringBuilder(initial), 'i', Stream.of(new BaseMatcher<Character>() {
+                    @Override
+                    public boolean matches(Object o) {
+                        return (char) o == 'z';
+                    }
+
+                    @Override
+                    public void describeTo(Description description) {
+
+                    }
+                })).toString());
+    }
+
+    @Test
+    public void testSingleCharMultipleOccurrenceUsingMatchingStrings() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "Thq quick brown fox jumpqd ovqr thq lazy dog";
+
+        assertEquals(expected,
+                underTest.remediateMatchingStrings(new StringBuilder(initial), 'q', "e").toString());
+    }
+
+    @Test
+    public void testSingleCharMultipleOccurrenceUsingPositions() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "Thq quick brown fox jumpqd ovqr thq lazy dog";
+
+        assertEquals(expected,
+                underTest.remediatePositions(new StringBuilder(initial), 'q', Stream.of(2, 24, 29, 34)).toString());
+    }
+
+    @Test
+    public void testSingleCharMultipleOccurrenceUsingMatcher() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "Thq quick brown fox jumpqd ovqr thq lazy dog";
+
+        assertEquals(expected,
+                underTest.remediateMatchingCharacters(new StringBuilder(initial), 'q', Stream.of(new BaseMatcher<Character>() {
+                    @Override
+                    public boolean matches(Object o) {
+                        return (char) o == 'e';
+                    }
+
+                    @Override
+                    public void describeTo(Description description) {
+
+                    }
+                })).toString());
+    }
+
+    @Test
+    public void testMultipleCharactersSingleOccurrence() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the lazy xxx";
+
+        assertEquals(expected,
+                underTest.remediateMatchingStrings(new StringBuilder(initial), 'x', "dog").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersMultipleOccurrence() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over xxe lazy dog";
+
+        assertEquals(expected,
+                underTest.remediateMatchingStrings(new StringBuilder(initial), 'x', "th").toString());
+    }
+
+    @Test
+    public void testMultipleCharactersMultipleOccurrenceMultipleStrings() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over xxe lazy xxx";
+
+        assertEquals(expected,
+                underTest.remediateMatchingStrings(new StringBuilder(initial), 'x', "th", "dog").toString());
+    }
+
+    @Test
+    public void testRemediateMatchingStringRegex() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the lazy xxx";
+
+        assertEquals(expected,
+                underTest.remediateMatchingStrings(new StringBuilder(initial), 'x', "dog").toString());
+    }
+
+    @Test
+    public void testRemediateMatchingStringRegexMultipleMatches() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brxwn fxx jumped xver the lazy dxg";
+
+        assertEquals(expected,
+                underTest.remediateMatchingStrings(new StringBuilder(initial), 'x', "o").toString());
+    }
+
+    @Test
+    public void testRemediateMatchingStringsJavadocExamples() throws Exception {
+        assertEquals("foo",
+                underTest.remediateMatchingStrings(
+                        new StringBuilder("foo"), 'X', "baz").toString());
+
+        assertEquals("fXX",
+                underTest.remediateMatchingStrings(
+                        new StringBuilder("foo"), 'X', "o").toString());
+
+        assertEquals("foo",
+                underTest.remediateMatchingStrings(
+                        new StringBuilder("foo"), 'X', "of").toString());
+
+        assertEquals("XXo",
+                underTest.remediateMatchingStrings(
+                        new StringBuilder("foo"), 'X', "fo").toString());
+    }
+
+    @Test
+    public void testRemediateEqualStringsJavadocExamples() throws Exception {
+        assertEquals("foo",
+                underTest.remediateEqualStrings(
+                        new StringBuilder("foo"), 'X', "baz").toString());
+
+        assertEquals("foo",
+                underTest.remediateEqualStrings(
+                        new StringBuilder("foo"), 'X', "o").toString());
+
+        assertEquals("foo",
+                underTest.remediateEqualStrings(
+                        new StringBuilder("foo"), 'X', "of").toString());
+
+        assertEquals("foo",
+                underTest.remediateEqualStrings(
+                        new StringBuilder("foo"), 'X', "fo").toString());
+
+        assertEquals("XXX",
+                underTest.remediateEqualStrings(
+                        new StringBuilder("foo"), 'X', "foo").toString());
+    }
+}

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/TruncationRemediationTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/support/validation/TruncationRemediationTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.packaging.tool.impl.support.validation;
+
+import org.junit.Test;
+
+import static org.dataconservancy.packaging.tool.impl.support.validation.TruncationRemediation.Strategy.LEADING_SUBSTITUTION;
+import static org.dataconservancy.packaging.tool.impl.support.validation.TruncationRemediation.Strategy.TRAILING_SUBSTITUTION;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Insures that the truncation remediation strategies work as expected.
+ * <p>
+ *
+ * </p>
+ */
+public class TruncationRemediationTest {
+
+    private TruncationRemediation underTest = new TruncationRemediation();
+
+    @Test
+    public void testLeadingSubstitutionPeriodAsReservedCharacter() throws Exception {
+        final String initial =  "The quick brown fox jumped over the lazy dog.";
+        final String expected = "X quick brown fox jumped over the lazy dog.";
+        final int limit = 43;
+
+        assertEquals(45, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testLeadingSubstitutionNoReservedCharacters() throws Exception {
+        final String initial = "The quick brown fox jumped over the lazy dog";
+        final String expected = "X quick brown fox jumped over the lazy dog";
+        final int limit = 42;
+
+        assertEquals(44, initial.length());
+        assertEquals(limit, expected.length());
+
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testTrailingSubstitutionPeriodAsReservedCharacter() throws Exception {
+        final String initial = "The quick brown fox jumped over the lazy dog.";
+        final String expected = "The quick brown fox jumped over the lazy X.";
+        final int limit = 43;
+
+        assertEquals(45, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, TRAILING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testTrailingSubstitutionNoReservedCharacters() throws Exception {
+        final String initial = "The quick brown fox jumped over the lazy dog";
+        final String expected = "The quick brown fox jumped over the lazy X";
+        final int limit = 42;
+
+        assertEquals(44, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, TRAILING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testLeadingSubstitutionWithReservedCharacterInIndex0() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+
+        final String initial = "/The quick brown fox jumped over the lazy dog.";
+        final String expected = "/X quick brown fox jumped over the lazy dog.";
+        final int limit = 44;
+
+        assertEquals(46, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testLeadingSubstitutionWithTwoReservedCharactersInIndex0() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+
+        final String initial = "//The quick brown fox jumped over the lazy dog.";
+        final String expected = "//X quick brown fox jumped over the lazy dog.";
+        final int limit = 45;
+
+        assertEquals(47, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testLeadingSubstitutionWithTwoConsecutiveReservedCharacters() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+
+        final String initial = "The quick brown fox // jumped over the lazy dog.";
+        final String expected = "X quick brown fox // jumped over the lazy dog.";
+        final int limit = 46;
+
+        assertEquals(48, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testLeadingSubstitutionWithFilePath() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+
+        final String initial = "/path/to/a/file.txt";
+        final String expected = "/X/X/a/file.txt";
+        final int limit = 15;
+
+        assertEquals(19, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testLeadingSubstitutionWithFilePathTwo() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+
+        final String initial = "/path/to/another/file.txt";
+        final String expected = "/X/X/X/file.txt";
+        final int limit = 15;
+
+        assertEquals(25, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testTrailingSubstitution() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+
+        final String initial = "/path/to/a/directory/";
+        final String expected = "/path/to/a/dirX/";
+        final int limit = 16;
+
+        assertEquals(21, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, TRAILING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testTrailingSubstitutionWithFilePath() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+
+        final String initial = "/path/to/a/file.txt";
+        final String expected = "/path/to/a/fX.X";
+        final int limit = 15;
+
+        assertEquals(19, initial.length());
+        assertEquals(limit, expected.length());
+
+        String actual = underTest.remediate(new StringBuilder(initial), limit, TRAILING_SUBSTITUTION);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testLeadingSubstitutionWithFullTruncation() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+        assertEquals('.', TruncationRemediation.RESERVED_CHARS[1]);
+
+        final String initial = "/path/to/a/file.txt";
+        final String expected = "/X/X/X/X.X";
+        final int limit = 10;
+
+        assertEquals(19, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test
+    public void testTruncateAlreadyTruncatedLeading() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+        assertEquals('.', TruncationRemediation.RESERVED_CHARS[1]);
+
+        final String initial = "/X/X/X/X.X";
+        final String expected = "/X/X/X/X.X";
+        final int limit = 10;
+
+        assertEquals(10, initial.length());
+        assertEquals(limit, expected.length());
+
+        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testTruncateAlreadyTruncatedLeadingUnableToMeetLimit() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+        assertEquals('.', TruncationRemediation.RESERVED_CHARS[1]);
+
+        final String initial = "/X/X/X/X.X";
+        final int limit = 9;
+
+        assertEquals(10, initial.length());
+
+        String result = underTest.remediate(new StringBuilder(initial), limit, LEADING_SUBSTITUTION);
+        System.err.println(result);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testTruncateAlreadyTruncatedTrailingUnableToMeetLimit() throws Exception {
+        assertEquals('/', TruncationRemediation.RESERVED_CHARS[0]);
+        assertEquals('.', TruncationRemediation.RESERVED_CHARS[1]);
+
+        final String initial = "/X/X/X/X.X";
+        final int limit = 9;
+
+        assertEquals(10, initial.length());
+
+        String result = underTest.remediate(new StringBuilder(initial), limit, TRAILING_SUBSTITUTION);
+        System.err.println(result);
+    }
+
+//
+//    @Test
+//    @Ignore("TODO")
+//    public void testPreserve() throws Exception {
+//        assertEquals(METADATA.getRelativePackageLocation(), TruncationRemediation.preserve(
+//                new StringBuilder(join("/", METADATA.getRelativePackageLocation(), "path", "to", "metadata")),
+//                TruncationRemediation.RESERVED_PATHS).toString());
+//    }
+
+    //    @Test
+//    public void testLeadingDeletion() throws Exception {
+//        final String initial =  "The quick brown fox jumped over the lazy dog.";
+//        final String expected = " quick brown fox jumped over the lazy dog.";
+//        final int limit = 42;
+//
+//        assertEquals(45, initial.length());
+//        assertEquals(limit, expected.length());
+//
+//        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, LEADING_DELETION));
+//    }
+//    @Test
+//    public void testTrailingSubstitution() throws Exception {
+//        final String initial =  "The quick brown fox jumped over the lazy dog.";
+//        final String expected = "The quick brown fox jumped over the lazy X";
+//        final int limit = 42;
+//
+//        assertEquals(45, initial.length());
+//        assertEquals(limit, expected.length());
+//
+//        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, TRAILING_SUBSTITUTION));
+//    }
+//
+//    @Test
+//    public void testTrailingDeletion() throws Exception {
+//        final String initial =  "The quick brown fox jumped over the lazy dog.";
+//        final String expected = "The quick brown fox jumped over the lazy ";
+//        final int limit = 41;
+//
+//        assertEquals(45, initial.length());
+//        assertEquals(limit, expected.length());
+//
+//        assertEquals(expected, underTest.remediate(new StringBuilder(initial), limit, TRAILING_DELETION));
+//    }
+
+    private void assertNoReservedChars(String str) {
+
+    }
+}

--- a/dcs-packaging-tool-integration/pom.xml
+++ b/dcs-packaging-tool-integration/pom.xml
@@ -48,6 +48,7 @@ under the License.
         <configuration>
           <excludes>
             <exclude>src/test/resources/**/*.txt</exclude>
+            <exclude>src/test/resources/TestContent/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/dcs-packaging-tool-integration/src/test/java/org/dataconservancy/packaging/tool/integration/PackageInitializer.java
+++ b/dcs-packaging-tool-integration/src/test/java/org/dataconservancy/packaging/tool/integration/PackageInitializer.java
@@ -57,7 +57,7 @@ public class PackageInitializer {
                     ipmService
                             .createTreeFromFileSystem(Paths
                                     .get(this.getClass()
-                                            .getResource("/TestContent/README")
+                                            .getResource("/TestContent/foo")
                                             .toURI()).getParent()
                                     .resolve("Parent_Dir"));
 

--- a/dcs-packaging-tool-model/src/main/java/org/dataconservancy/packaging/tool/model/PackagingToolReturnInfo.java
+++ b/dcs-packaging-tool-model/src/main/java/org/dataconservancy/packaging/tool/model/PackagingToolReturnInfo.java
@@ -57,7 +57,8 @@ public enum PackagingToolReturnInfo {
     PKG_ASSEMBLER_INVALID_PARAMS (406, "One or more initial parameters for the package assembler was invalid "),
     PKG_ASSEMBLER_STRAY_FILE (407, "One or more of the files provided to the package assembler do not reside under the specified" +
             " content root location"),
-    PKG_ASSEMBLER_INVALID_FILENAME (408, "One or more of the files provided to the package assembler has an invalid file name."),
+    PKG_ASSEMBLER_INVALID_FILENAME (408, "One or more of the files provided to the package assembler has an invalid file name, or the file path was too long"),
+    PKG_ASSEMBLER_DUPLICATE_RESOURCE(409, "The resource at the specified path has already been reserved"),
 
     /* exception relating to Package Generator */
     PKG_UNEXPECTED_PACKAGING_FORMAT ( 501, "Package format provided was not as expected."),

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,12 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.10.19</version>
+      </dependency>
+
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
Current behavior of the GUI is to disallow the creation of package resources that violate the Data Conservancy Package Profile 1.0 section [2.2.2](http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2).

This can be problematic for data found "in the wild", because many files may violate section 2.2.2 and prevent them from being packaged by the GUI.

This PR will automatically remediate invalid package resource paths.  In short, illegal characters are replaced by `X`, and paths that exceed [length requirements](http://dataconservancy.github.io/dc-packaging-spec/dc-bagit-profile-1.0.html#a2.2.2.3) are automatically truncated, where an `X` represents truncated characters.

The original name of the file or directory can be found in the domain object RDF. 

Addresses #26 