### PR TITLE
Allow large file sizes by using POSIX.1-2001/pax extensions.  Closes #35.

### DIFF
--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -656,6 +656,7 @@ public class BagItPackageAssembler implements PackageAssembler {
                     .createArchiveOutputStream(archivingFormat, new BufferedOutputStream(fos));
             if (aos instanceof TarArchiveOutputStream) {
                 ((TarArchiveOutputStream) aos).setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+                ((TarArchiveOutputStream) aos).setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
             }
             // Get to putting all the files in the compressed output file
             if (bagBaseDir.listFiles() != null) {

--- a/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssemblerTest.java
+++ b/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssemblerTest.java
@@ -258,6 +258,21 @@ public class BagItPackageAssemblerTest {
     }
 
     @Test
+    public void testAssembleTarWithLargeFile() throws Exception {
+        PackageGenerationParameters params = new PackageGenerationParameters();
+        setupCommonPackageParams(params, packageMetadata);
+        params.removeParam(BagItParameterNames.ARCHIVING_FORMAT);
+        params.addParam(BagItParameterNames.ARCHIVING_FORMAT, ArchiveStreamFactory.TAR);
+
+        underTest = new BagItPackageAssembler();
+        underTest.init(params, packageMetadata);
+
+        underTest.createResource("path/to/largefile.bin", PackageResourceType.DATA,
+                new NullInputStream(077777777777L + 1));
+        underTest.assemblePackage();
+    }
+
+    @Test
     public void testPutResource() throws IOException {
         //Reserve a URI
         String filePath = "metadataFile.txt";


### PR DESCRIPTION
Allow large file sizes by using POSIX.1-2001/pax extensions.  Closes #35.