### PR TITLE
Include a unique id in the staging directory name.  When an archive (tar, zip) form of a bag is being prepared, it will be staged in a unique location each time, unless a package staging location has been specifically requested in the package generation parameters.

### DIFF
--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -238,7 +239,9 @@ public class BagItPackageAssembler implements PackageAssembler {
             if (packageStagingLocationParameterValue != null && !packageStagingLocationParameterValue.isEmpty()) {
                 packageStagingLocationName = packageStagingLocationParameterValue;
             } else {
-                packageStagingLocationName = System.getProperty("java.io.tmpdir") + File.separator + "DCS-PackageToolStaging";
+                packageStagingLocationName = System.getProperty("java.io.tmpdir") +
+                        File.separator + "DCS-PackageToolStaging" +
+                        File.separator + UUID.randomUUID().toString();
             }
         }
 


### PR DESCRIPTION
Include a unique id in the staging directory name.  When an archive (tar, zip) form of a bag is being prepared, it will be staged in a unique location each time, unless a package staging location has been specifically requested in the package generation parameters.

Closes #19.