### PR TITLE
Insure the path remediation test covers the combining diacritic as we…

### DIFF
--- a/dcs-packaging-tool-integration/src/test/java/org/dataconservancy/packaging/tool/integration/PackageGenerationTest.java
+++ b/dcs-packaging-tool-integration/src/test/java/org/dataconservancy/packaging/tool/integration/PackageGenerationTest.java
@@ -216,7 +216,8 @@ public class PackageGenerationTest {
 
                     // this should not happen, because a file name with invalid characters should have
                     // been remediated prior to being inserted into the package
-                    if (node.getFileInfo().getLocation().getPath().endsWith("README" + '\u0301')) {
+                    if (node.getFileInfo().getLocation().getPath().endsWith("README" + '\u0301') ||
+                            node.getFileInfo().getLocation().getPath().endsWith("READM" + '\u00c9') ) {
                         foundIllegal.set(Boolean.TRUE);
                     }
 


### PR DESCRIPTION
…ll as the decomposed version of the capital E with acute.