### PR TITLE
Insure that a unique directory is used to stage package content

### DIFF
--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -237,6 +237,11 @@ public class BagItPackageAssembler implements PackageAssembler {
                 packageStagingLocationName = packageLocationParameterValue;
         } else {
             if (packageStagingLocationParameterValue != null && !packageStagingLocationParameterValue.isEmpty()) {
+                if (!new File(packageLocationParameterValue).isAbsolute()) {
+                    throw new PackageToolException(PackagingToolReturnInfo.PKG_DIR_CREATION_EXP,
+                            "\nAttempt to create staging directory for the package at \"" + packageLocationParameterValue +
+                            "\" failed. The 'Package-Staging-Location' parameter must specify an absolute path.");
+                }
                 packageStagingLocationName = packageStagingLocationParameterValue + File.separator + UUID.randomUUID().toString();
             } else {
                 packageStagingLocationName = System.getProperty("java.io.tmpdir") +

--- a/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
+++ b/dcs-packaging-tool-impl/src/main/java/org/dataconservancy/packaging/tool/impl/generator/BagItPackageAssembler.java
@@ -237,7 +237,7 @@ public class BagItPackageAssembler implements PackageAssembler {
                 packageStagingLocationName = packageLocationParameterValue;
         } else {
             if (packageStagingLocationParameterValue != null && !packageStagingLocationParameterValue.isEmpty()) {
-                packageStagingLocationName = packageStagingLocationParameterValue;
+                packageStagingLocationName = packageStagingLocationParameterValue + File.separator + UUID.randomUUID().toString();
             } else {
                 packageStagingLocationName = System.getProperty("java.io.tmpdir") +
                         File.separator + "DCS-PackageToolStaging" +


### PR DESCRIPTION
Insures that a unique directory is used to stage package content when the end-user overrides the staging directory using the `Package-Staging-Location` parameter in `~/.dataconservancy/packageGenerationParameters`.

* The value for `Package-Staging-Location` _must_ be an absolute directory
* This PR appends a unique directory name to the path specified by `Package-Staging-Location`

See also (#19)