### PR TITLE
Specify packaging directory for ITs

### DIFF
--- a/dcs-packaging-tool-impl/pom.xml
+++ b/dcs-packaging-tool-impl/pom.xml
@@ -91,6 +91,9 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
+            <dcs.package.tool.package.dir>${project.build.testOutputDirectory}/generated-packages</dcs.package.tool.package.dir>
+            <dcs.package.tool.staging.dir>${project.build.testOutputDirectory}/package-staging</dcs.package.tool.staging.dir>
+            <dcs.package.tool.test.content>${project.basedir}/src/test/resources</dcs.package.tool.test.content>
             <logback.configurationFile>${project.basedir}/src/test/resources/logback-test.xml</logback.configurationFile>
           </systemPropertyVariables>
         </configuration>


### PR DESCRIPTION
The system properties for specifying packaging directory were undefined
for ITs, leading to the creation of a directory literally named
`$dcs.package.tool.package.dir}` in the cwd.

Resolves #64